### PR TITLE
Fix responding to blockwise requests using Write

### DIFF
--- a/blockwise.go
+++ b/blockwise.go
@@ -666,7 +666,13 @@ func handleBlockWiseMsg(w ResponseWriter, r *Request, next func(w ResponseWriter
 				if err != nil {
 					return
 				}
-				next(w, &Request{Client: r.Client, Msg: msg})
+
+				// We need to be careful to create a new response writer for the
+				// new request, otherwise the server may attempt to respond to
+				// the wrong request.
+				newReq := &Request{Client: r.Client, Msg: msg}
+				newWriter := responseWriterFromRequest(newReq)
+				next(newWriter, newReq)
 				return
 			}
 			/*

--- a/responsewriter.go
+++ b/responsewriter.go
@@ -38,6 +38,26 @@ type responseWriter struct {
 	contentFormat *MediaType
 }
 
+func responseWriterFromRequest(r *Request) ResponseWriter {
+	w := ResponseWriter(&responseWriter{req: r})
+	switch {
+	case r.Msg.Code() == GET:
+		switch {
+		// set blockwise notice writer for observe
+		case r.Client.networkSession.blockWiseEnabled() && r.Msg.Option(Observe) != nil:
+			w = &blockWiseNoticeWriter{responseWriter: w.(*responseWriter)}
+		// set blockwise if it is enabled
+		case r.Client.networkSession.blockWiseEnabled():
+			w = &blockWiseResponseWriter{responseWriter: w.(*responseWriter)}
+		}
+		w = &getResponseWriter{w}
+	case r.Client.networkSession.blockWiseEnabled():
+		w = &blockWiseResponseWriter{responseWriter: w.(*responseWriter)}
+	}
+
+	return w
+}
+
 // NewResponse creates reponse for request
 func (r *responseWriter) NewResponse(code COAPCode) Message {
 	typ := NonConfirmable

--- a/server.go
+++ b/server.go
@@ -583,21 +583,7 @@ func (srv *Server) serveUDP(conn *net.UDPConn) error {
 }
 
 func (srv *Server) serve(r *Request) {
-	w := ResponseWriter(&responseWriter{req: r})
-	switch {
-	case r.Msg.Code() == GET:
-		switch {
-		// set blockwise notice writer for observe
-		case r.Client.networkSession.blockWiseEnabled() && r.Msg.Option(Observe) != nil:
-			w = &blockWiseNoticeWriter{responseWriter: w.(*responseWriter)}
-		// set blockwise if it is enabled
-		case r.Client.networkSession.blockWiseEnabled():
-			w = &blockWiseResponseWriter{responseWriter: w.(*responseWriter)}
-		}
-		w = &getResponseWriter{w}
-	case r.Client.networkSession.blockWiseEnabled():
-		w = &blockWiseResponseWriter{responseWriter: w.(*responseWriter)}
-	}
+	w := responseWriterFromRequest(r)
 
 	handlePairMsg(w, r, func(w ResponseWriter, r *Request) {
 		handleSignalMsg(w, r, func(w ResponseWriter, r *Request) {


### PR DESCRIPTION
When responding to blockwise requests using `ResponseWrite.Write` the server would use the message ID of the first block message rather than the last. This meant that clients would fail to handle the response.

This was due to not creating a new response writer when we created a new request.