### PR TITLE
support no-response option

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ Features supported:
 * CoAP over UDP [RFC 7252][coap].
 * CoAP over TCP/TLS [RFC 8232][coap-tcp]
 * Observe resources in CoAP [RFC 7641][coap-observe]
-* Block-wise transfers in COAP [RFC 7959][coap-block-wise-transfers]
+* Block-wise transfers in CoAP [RFC 7959][coap-block-wise-transfers]
 * request multiplexer
 * multicast
+* CoAP NoResponse option in CoAP [RFC 7967][coap-noresponse]
 
 Not yet implemented:
 * CoAP over DTLS
@@ -19,6 +20,7 @@ Not yet implemented:
 [coap-tcp]: https://tools.ietf.org/html/rfc8323
 [coap-block-wise-transfers]: https://tools.ietf.org/html/rfc7959
 [coap-observe]: https://tools.ietf.org/html/rfc7641
+[coap-noresponse]: https://tools.ietf.org/html/rfc7967
 
 ## Samples
 

--- a/error.go
+++ b/error.go
@@ -103,3 +103,6 @@ const ErrInvalidPayload = Error("invalid payload")
 
 //ErrUnexpectedReponseCode unexpected response code occurs
 const ErrUnexpectedReponseCode = Error("unexpected response code")
+
+// ErrMessageNotInterested message is not of interest to the client
+const ErrMessageNotInterested = Error("message not to be sent due to disinterest")

--- a/message.go
+++ b/message.go
@@ -146,7 +146,7 @@ func (c COAPCode) String() string {
 }
 
 // OptionID identifies an option in a message.
-type OptionID uint8
+type OptionID uint16
 
 /*
    +-----+----+---+---+---+----------------+--------+--------+---------+
@@ -197,6 +197,7 @@ const (
 	ProxyURI      OptionID = 35
 	ProxyScheme   OptionID = 39
 	Size1         OptionID = 60
+	NoResponse    OptionID = 258
 )
 
 // Option value format (RFC7252 section 3.2)
@@ -236,6 +237,7 @@ var coapOptionDefs = map[OptionID]optionDef{
 	ProxyURI:      optionDef{valueFormat: valueString, minLen: 1, maxLen: 1034},
 	ProxyScheme:   optionDef{valueFormat: valueString, minLen: 1, maxLen: 255},
 	Size1:         optionDef{valueFormat: valueUint, minLen: 0, maxLen: 4},
+	NoResponse:    optionDef{valueFormat: valueUint, minLen: 0, maxLen: 1},
 }
 
 // MediaType specifies the content format of a message.

--- a/message_test.go
+++ b/message_test.go
@@ -817,6 +817,7 @@ func TestEncodeMessageWithAllOptions(t *testing.T) {
 	req.AddOption(Block1, uint32(66560))
 	req.AddOption(Size2, uint32(9999))
 	req.AddOption(Block2, uint32(66560))
+	req.AddOption(NoResponse, uint32(26))
 
 	buf := &bytes.Buffer{}
 	err := req.MarshalBinary(buf)
@@ -828,6 +829,7 @@ func TestEncodeMessageWithAllOptions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error parsing binary packet: %v", err)
 	}
+
 	assertEqualMessages(t, req, parsedMsg)
 }
 
@@ -1076,5 +1078,22 @@ func TestBlockWiseTransfer(t *testing.T) {
 
 	if peer1_1Msg.Option(Block2).(uint32) != 22 {
 		t.Fatalf("peer1_1Msg.Option(Block2): %v", peer1_1Msg.Option(Block2).(uint32))
+	}
+}
+
+func TestDecodeMessageWithNoResponseOption(t *testing.T) {
+	data := []byte{
+		0x45, 0x1, 0x30, 0x39, 0x54, 0x4f, 0x4b, 0x45,
+		0x4e, 0xd1, 0xf5, 0x1a, 0xff, 0x50, 0x41, 0x59,
+		0x4c, 0x4f, 0x41, 0x44,
+	}
+
+	parsedMsg, err := ParseDgramMessage(data)
+	if err != nil {
+		t.Fatalf("Error parsing binary packet: %v", err)
+	}
+
+	if parsedMsg.Option(NoResponse).(uint32) != 26 {
+		t.Fatalf("parsedMsg.Option(NoResponse): %v", parsedMsg.Option(NoResponse).(uint32))
 	}
 }

--- a/noresponsewriter.go
+++ b/noresponsewriter.go
@@ -1,0 +1,76 @@
+package coap
+
+func isSet(n uint32, pos uint32) bool {
+	val := n & (1 << pos)
+	return (val > 0)
+}
+
+func powerOfTwo(exponent uint32) uint32 {
+	if exponent != 0 {
+		return (2 * powerOfTwo(exponent-1))
+	}
+	return 1
+}
+
+func (w *noResponseWriter) decodeNoResponseOption(v uint32) []COAPCode {
+	var codes []COAPCode
+	if v == 0 {
+		// No suppresed code
+		return codes
+	}
+
+	var i uint32
+	// Max possible value:16; ref:table_2_rfc7967
+	for i = 0; i <= 4; i++ {
+		if isSet(v, i) {
+			index := powerOfTwo(i)
+			codes = append(codes, w.noResponseValueMap[index]...)
+		}
+	}
+	return codes
+}
+
+type noResponseWriter struct {
+	*responseWriter
+	noResponseValueMap map[uint32][]COAPCode
+}
+
+func newNoResponseWriter(w ResponseWriter) *noResponseWriter {
+	return &noResponseWriter{
+		responseWriter: w.(*responseWriter),
+		noResponseValueMap: map[uint32][]COAPCode{
+			2:  []COAPCode{Created, Deleted, Valid, Changed, Content},
+			8:  []COAPCode{BadRequest, Unauthorized, BadOption, Forbidden, NotFound, MethodNotAllowed, NotAcceptable, PreconditionFailed, RequestEntityTooLarge, UnsupportedMediaType},
+			16: []COAPCode{InternalServerError, NotImplemented, BadGateway, ServiceUnavailable, GatewayTimeout, ProxyingNotSupported},
+		},
+	}
+}
+
+func (w *noResponseWriter) WriteMsg(msg Message) error {
+	noRespValue, ok := w.req.Msg.Option(NoResponse).(uint32)
+	if !ok {
+		return ErrNotSupported
+	}
+	suppressedCodes := w.decodeNoResponseOption(noRespValue)
+
+	for _, code := range suppressedCodes {
+		if code == msg.Code() {
+			return ErrMessageNotInterested
+		}
+	}
+	return w.req.Client.WriteMsg(msg)
+}
+
+func (w *noResponseWriter) Write(p []byte) (n int, err error) {
+	l, resp := prepareReponse(w, w.responseWriter.req.Msg.Code(), w.responseWriter.code, w.responseWriter.contentFormat, p)
+	err = w.WriteMsg(resp)
+	return l, err
+}
+
+func (w *noResponseWriter) SetCode(code COAPCode) {
+	w.code = &code
+}
+
+func (w *noResponseWriter) SetContentFormat(contentFormat MediaType) {
+	w.contentFormat = &contentFormat
+}

--- a/noresponsewriter_test.go
+++ b/noresponsewriter_test.go
@@ -49,3 +49,54 @@ func TestNoResponseAllCodes(t *testing.T) {
 		t.Fatalf("Expected\n%#v\ngot\n%#v", exp, codes)
 	}
 }
+
+func testNoResponseHandler(t *testing.T, w ResponseWriter, r *Request) {
+	msg := r.Client.NewMessage(MessageParams{
+		Type:      Acknowledgement,
+		Code:      NotFound,
+		MessageID: r.Msg.MessageID(),
+		Token:     r.Msg.Token(),
+	})
+
+	err := w.WriteMsg(msg)
+	if err != nil {
+		if err == ErrMessageNotInterested {
+			t.Fatalf("server unable to write message: %v", err)
+		}
+		return
+	}
+}
+
+func TestNoResponseBehaviour(t *testing.T) {
+	// server creation
+	s, addr, fin, err := RunLocalServerUDPWithHandler("udp", ":", false, BlockWiseSzx16, func(w ResponseWriter, r *Request) { testNoResponseHandler(t, w, r) })
+	defer func() {
+		s.Shutdown()
+		<-fin
+	}()
+	if err != nil {
+		t.Fatalf("Unexpected error '%v'", err)
+	}
+
+	// connect client
+	c := Client{Net: "udp"}
+	con, err := c.Dial(addr)
+	if err != nil {
+		t.Fatalf("Unexpected error '%v'", err)
+	}
+
+	// send client request
+	req := &DgramMessage{
+		MessageBase{
+			typ:       NonConfirmable,
+			code:      GET,
+			messageID: 1234,
+		}}
+
+	// supressing 2XX code: example Content; No error when server sends 4XX response
+	req.SetOption(NoResponse, 2)
+	err = con.WriteMsg(req)
+	if err != nil {
+		t.Fatalf("client unable to write message: %v", err)
+	}
+}

--- a/noresponsewriter_test.go
+++ b/noresponsewriter_test.go
@@ -1,0 +1,51 @@
+package coap
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNoResponse2XXCodes(t *testing.T) {
+	nr := newNoResponseWriter(ResponseWriter(&responseWriter{req: &Request{}}))
+	codes := nr.decodeNoResponseOption(2)
+	exp := resp2XXCodes
+	if !reflect.DeepEqual(exp, codes) {
+		t.Fatalf("Expected\n%#v\ngot\n%#v", exp, codes)
+	}
+}
+
+func TestNoResponse4XXCodes(t *testing.T) {
+	nr := newNoResponseWriter(ResponseWriter(&responseWriter{req: &Request{}}))
+	codes := nr.decodeNoResponseOption(8)
+	exp := resp4XXCodes
+	if !reflect.DeepEqual(exp, codes) {
+		t.Fatalf("Expected\n%#v\ngot\n%#v", exp, codes)
+	}
+}
+
+func TestNoResponse5XXCodes(t *testing.T) {
+	nr := newNoResponseWriter(ResponseWriter(&responseWriter{req: &Request{}}))
+	codes := nr.decodeNoResponseOption(16)
+	exp := resp5XXCodes
+	if !reflect.DeepEqual(exp, codes) {
+		t.Fatalf("Expected\n%#v\ngot\n%#v", exp, codes)
+	}
+}
+
+func TestNoResponseCombinationXXCodes(t *testing.T) {
+	nr := newNoResponseWriter(ResponseWriter(&responseWriter{req: &Request{}}))
+	codes := nr.decodeNoResponseOption(18)
+	exp := append(resp2XXCodes, resp5XXCodes...)
+	if !reflect.DeepEqual(exp, codes) {
+		t.Fatalf("Expected\n%#v\ngot\n%#v", exp, codes)
+	}
+}
+
+func TestNoResponseAllCodes(t *testing.T) {
+	nr := newNoResponseWriter(ResponseWriter(&responseWriter{req: &Request{}}))
+	codes := nr.decodeNoResponseOption(0)
+	exp := []COAPCode(nil)
+	if !reflect.DeepEqual(exp, codes) {
+		t.Fatalf("Expected\n%#v\ngot\n%#v", exp, codes)
+	}
+}

--- a/responsewriter.go
+++ b/responsewriter.go
@@ -61,6 +61,9 @@ func responseWriterFromRequest(r *Request) ResponseWriter {
 	case r.Client.networkSession().blockWiseEnabled():
 		w = &blockWiseResponseWriter{responseWriter: w}
 	}
+	if r.Msg.Option(NoResponse) != nil {
+		w = newNoResponseWriter(w)
+	}
 
 	return w
 }


### PR DESCRIPTION
OptionID has to be made uint16 in order to support the no-response
option number i.e. 258.
Added Encoding and Decoding message tests for the no-response option.
Reference: https://tools.ietf.org/html/rfc7967