### PR TITLE
Switch order of operands in DTLS timeout calculation

### DIFF
--- a/net/connDTLS.go
+++ b/net/connDTLS.go
@@ -97,7 +97,7 @@ func (c *ConnDTLS) Read(b []byte) (n int, err error) {
 	select {
 	case d := <-c.readDataCh:
 		return c.processData(b, d)
-	case <-time.After(time.Now().Sub(deadline)):
+	case <-time.After(deadline.Sub(time.Now())):
 		return 0, errS{
 			error:     fmt.Errorf(ioTimeout),
 			temporary: true,


### PR DESCRIPTION
I have used `go-coap` (commit 4d60089651dfdc4b0f0ff5011c121c53535dfd5b) in a DTLS setting and CPU usage spikes pretty soon on both macOS and Rasbian. After some investigation and profiling, I think I have found the issue to be a timeout calculation bug in the `net/connDTLS.go` file where a delay is computed by subtracting a deadline from a `time.Now` call. I assume the deadline should be sometime in the future most of the time and thus the result is often negative. Things look better to me if the order of the operands are changed.

With the provided fix, CPU usage is much more reasonable!

