### PR TITLE
ListenAndServe should only return on shutdown or fatal error

### DIFF
--- a/error.go
+++ b/error.go
@@ -1,5 +1,7 @@
 package coap
 
+import "github.com/go-ocf/go-coap/net"
+
 // Error errors type of coap
 type Error string
 
@@ -107,5 +109,8 @@ const ErrUnexpectedReponseCode = Error("unexpected response code")
 // ErrMessageNotInterested message is not of interest to the client
 const ErrMessageNotInterested = Error("message not to be sent due to disinterest")
 
-// ErrMaxMessageSizeLimitExceeded message size bigger thab maximum message size limit
+// ErrMaxMessageSizeLimitExceeded message size bigger than maximum message size limit
 const ErrMaxMessageSizeLimitExceeded = Error("maximum message size limit exceeded")
+
+// ErrServerClosed Server closed
+const ErrServerClosed = net.ErrServerClosed

--- a/net/dtlslistener.go
+++ b/net/dtlslistener.go
@@ -72,7 +72,7 @@ func (l *DTLSListener) AcceptWithContext(ctx context.Context) (net.Conn, error) 
 		select {
 		case <-ctx.Done():
 			if ctx.Err() != nil {
-				return nil, fmt.Errorf("cannot accept connections: %v", ctx.Err())
+				return nil, ErrServerClosed
 			}
 			return nil, nil
 		default:

--- a/net/error.go
+++ b/net/error.go
@@ -1,0 +1,7 @@
+package net
+
+type Error string
+
+func (e Error) Error() string { return string(e) }
+
+const ErrServerClosed = Error("server closed")

--- a/net/tcplistener.go
+++ b/net/tcplistener.go
@@ -42,7 +42,7 @@ func (l *TCPListener) AcceptWithContext(ctx context.Context) (net.Conn, error) {
 		select {
 		case <-ctx.Done():
 			if ctx.Err() != nil {
-				return nil, fmt.Errorf("cannot accept connections: %v", ctx.Err())
+				return nil, ErrServerClosed
 			}
 			return nil, nil
 		default:

--- a/net/tlslistener.go
+++ b/net/tlslistener.go
@@ -36,7 +36,7 @@ func (l *TLSListener) AcceptWithContext(ctx context.Context) (net.Conn, error) {
 		select {
 		case <-ctx.Done():
 			if ctx.Err() != nil {
-				return nil, fmt.Errorf("cannot accept connections: %v", ctx.Err())
+				return nil, ErrServerClosed
 			}
 			return nil, nil
 		default:

--- a/server.go
+++ b/server.go
@@ -532,8 +532,13 @@ func (srv *Server) serveDTLSListener(l Listener) error {
 	for {
 		rw, err := l.AcceptWithContext(ctx)
 		if err != nil {
-			wg.Wait()
-			return fmt.Errorf("cannot serve dtls: %v", err)
+			switch err {
+			case ErrServerClosed:
+				wg.Wait()
+				return fmt.Errorf("cannot serve dtls: %v", err)
+			default:
+				continue
+			}
 		}
 		if rw != nil {
 			wg.Add(1)
@@ -601,8 +606,13 @@ func (srv *Server) serveTCPListener(l Listener) error {
 	for {
 		rw, err := l.AcceptWithContext(ctx)
 		if err != nil {
-			wg.Wait()
-			return fmt.Errorf("cannot serve tcp: %v", err)
+			switch err {
+			case ErrServerClosed:
+				wg.Wait()
+				return fmt.Errorf("cannot serve tcp: %v", err)
+			default:
+				continue
+			}
 		}
 		if rw != nil {
 			wg.Add(1)


### PR DESCRIPTION
@jkralik 
Regarding issue https://github.com/go-ocf/go-coap/issues/67

The review has a lot of noise due to moving net package into coap.  The reason I did that was because I made use of error objects in error.go that's in the coap package and seems like it should be accessible as "coap.ErrServerClosed".  Similar to the golang http library "http.ErrServerClosed".  Let me know if you want to restructure a different way instead.

The important changes are in dtlslistener.go, tlslistener.go, tcplistener.go where it returns ErrServerClosed on the context.Done() channel on shutdown.  Then inside of the accept loops for DTLS, TCP, etc, inside of server.go, instead of returning on every error, we continue and only return when an ErrServerClosed error is encountered.