### PR TITLE
feat(cert): add peer certificates to the incoming request

### DIFF
--- a/client.go
+++ b/client.go
@@ -5,6 +5,7 @@ package coap
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"io"
 	"net"
@@ -325,6 +326,11 @@ func (co *ClientConn) LocalAddr() net.Addr {
 // RemoteAddr implements the networkSession.RemoteAddr method.
 func (co *ClientConn) RemoteAddr() net.Addr {
 	return co.commander.RemoteAddr()
+}
+
+// PeerCertificates implements the networkSession.PeerCertificates method.
+func (co *ClientConn) PeerCertificates() []*x509.Certificate {
+	return co.commander.PeerCertificates()
 }
 
 func (co *ClientConn) Exchange(m Message) (Message, error) {

--- a/clientcommander.go
+++ b/clientcommander.go
@@ -3,6 +3,7 @@ package coap
 import (
 	"bytes"
 	"context"
+	"crypto/x509"
 	"io"
 	"io/ioutil"
 	"net"
@@ -86,6 +87,11 @@ func (cc *ClientCommander) LocalAddr() net.Addr {
 // RemoteAddr implements the networkSession.RemoteAddr method.
 func (cc *ClientCommander) RemoteAddr() net.Addr {
 	return cc.networkSession.RemoteAddr()
+}
+
+// PeerCertificates implements the networkSession.PeerCertificates method.
+func (cc *ClientCommander) PeerCertificates() []*x509.Certificate {
+	return cc.networkSession.PeerCertificates()
 }
 
 // Equal compare two ClientCommanders

--- a/net/conn.go
+++ b/net/conn.go
@@ -34,6 +34,11 @@ func (c *Conn) LocalAddr() net.Addr {
 	return c.connection.LocalAddr()
 }
 
+// Connection returns the network connection. The Conn returned is shared by all invocations of Connection, so do not modify it.
+func (c *Conn) Connection() net.Conn {
+	return c.connection
+}
+
 // RemoteAddr returns the remote network address. The Addr returned is shared by all invocations of RemoteAddr, so do not modify it.
 func (c *Conn) RemoteAddr() net.Addr {
 	return c.connection.RemoteAddr()

--- a/networksession.go
+++ b/networksession.go
@@ -2,6 +2,7 @@ package coap
 
 import (
 	"context"
+	"crypto/x509"
 	"net"
 )
 
@@ -12,6 +13,9 @@ type networkSession interface {
 	LocalAddr() net.Addr
 	// RemoteAddr returns the net.Addr of the client that sent the current request.
 	RemoteAddr() net.Addr
+	// PeerCertificates returns the certificate chain presented by the remote
+	// peer of the current request.
+	PeerCertificates() []*x509.Certificate
 	// WriteContextMsg writes a reply back to the client.
 	WriteMsgWithContext(ctx context.Context, resp Message) error
 	// Close closes the connection.

--- a/request.go
+++ b/request.go
@@ -2,13 +2,11 @@ package coap
 
 import (
 	"context"
-	"crypto/x509"
 )
 
 type Request struct {
-	Msg              Message
-	PeerCertificates []*x509.Certificate
-	Client           *ClientConn
-	Ctx              context.Context
-	Sequence         uint64 // discontinuously growing number for every request from connection starts from 0
+	Msg      Message
+	Client   *ClientConn
+	Ctx      context.Context
+	Sequence uint64 // discontinuously growing number for every request from connection starts from 0
 }

--- a/request.go
+++ b/request.go
@@ -1,10 +1,14 @@
 package coap
 
-import "context"
+import (
+	"context"
+	"crypto/x509"
+)
 
 type Request struct {
-	Msg      Message
-	Client   *ClientConn
-	Ctx      context.Context
-	Sequence uint64 // discontinuously growing number for every request from connection starts from 0
+	Msg              Message
+	PeerCertificates []*x509.Certificate
+	Client           *ClientConn
+	Ctx              context.Context
+	Sequence         uint64 // discontinuously growing number for every request from connection starts from 0
 }

--- a/server.go
+++ b/server.go
@@ -2,8 +2,10 @@
 package coap
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"net"
 	"reflect"
@@ -553,7 +555,15 @@ func (srv *Server) serveDTLSConnection(ctx *shutdownContext, conn *coapNet.Conn)
 		// We will block poller wait loop when
 		// all pool workers are busy.
 		c := ClientConn{commander: &ClientCommander{session}}
-		srv.spawnWorker(&Request{Client: &c, Msg: msg, Ctx: sessCtx, Sequence: c.Sequence()})
+
+		// Try to set the peer certificates, but don't error if it fails as there
+		// might not be any peer certificates.
+		dtlsConn := conn.Connection().(*dtls.Conn)
+		cert := dtlsConn.RemoteCertificate()
+		flatCerts := bytes.Join(cert, nil)
+		certs, _ := x509.ParseCertificates(flatCerts)
+
+		srv.spawnWorker(&Request{Client: &c, PeerCertificates: certs, Msg: msg, Ctx: sessCtx, Sequence: c.Sequence()})
 	}
 }
 

--- a/server.go
+++ b/server.go
@@ -2,10 +2,8 @@
 package coap
 
 import (
-	"bytes"
 	"context"
 	"crypto/tls"
-	"crypto/x509"
 	"fmt"
 	"net"
 	"reflect"
@@ -555,15 +553,7 @@ func (srv *Server) serveDTLSConnection(ctx *shutdownContext, conn *coapNet.Conn)
 		// We will block poller wait loop when
 		// all pool workers are busy.
 		c := ClientConn{commander: &ClientCommander{session}}
-
-		// Try to set the peer certificates, but don't error if it fails as there
-		// might not be any peer certificates.
-		dtlsConn := conn.Connection().(*dtls.Conn)
-		cert := dtlsConn.RemoteCertificate()
-		flatCerts := bytes.Join(cert, nil)
-		certs, _ := x509.ParseCertificates(flatCerts)
-
-		srv.spawnWorker(&Request{Client: &c, PeerCertificates: certs, Msg: msg, Ctx: sessCtx, Sequence: c.Sequence()})
+		srv.spawnWorker(&Request{Client: &c, Msg: msg, Ctx: sessCtx, Sequence: c.Sequence()})
 	}
 }
 

--- a/sessiondtls.go
+++ b/sessiondtls.go
@@ -33,18 +33,21 @@ func newSessionDTLS(connection *coapNet.Conn, srv *Server) (networkSession, erro
 		return nil, ErrInvalidBlockWiseSzx
 	}
 
-	dtlsConn := connection.Connection().(*dtls.Conn)
-	cert := dtlsConn.RemoteCertificate()
-	flatCerts := bytes.Join(cert, nil)
-	peerCertificates, err := x509.ParseCertificates(flatCerts)
-	if err != nil {
-		return nil, err
+	s := sessionDTLS{
+		sessionBase: newBaseSession(BlockWiseTransfer, BlockWiseTransferSzx, srv),
+		connection:  connection,
 	}
 
-	s := sessionDTLS{
-		sessionBase:      newBaseSession(BlockWiseTransfer, BlockWiseTransferSzx, srv),
-		connection:       connection,
-		peerCertificates: peerCertificates,
+	dtlsConn := connection.Connection().(*dtls.Conn)
+	cert := dtlsConn.RemoteCertificate()
+	if len(cert) > 0 {
+		flatCerts := bytes.Join(cert, nil)
+		peerCertificates, err := x509.ParseCertificates(flatCerts)
+		if err != nil {
+			return nil, err
+		}
+
+		s.peerCertificates = peerCertificates
 	}
 
 	return &s, nil

--- a/sessiontcp.go
+++ b/sessiontcp.go
@@ -3,6 +3,7 @@ package coap
 import (
 	"bytes"
 	"context"
+	"crypto/x509"
 	"fmt"
 	"net"
 	"sync/atomic"
@@ -53,6 +54,11 @@ func (s *sessionTCP) LocalAddr() net.Addr {
 // RemoteAddr implements the networkSession.RemoteAddr method.
 func (s *sessionTCP) RemoteAddr() net.Addr {
 	return s.connection.RemoteAddr()
+}
+
+// PeerCertificates implements the networkSession.PeerCertificates method.
+func (s *sessionTCP) PeerCertificates() []*x509.Certificate {
+	return nil
 }
 
 func (s *sessionTCP) blockWiseEnabled() bool {

--- a/sessionudp.go
+++ b/sessionudp.go
@@ -3,6 +3,7 @@ package coap
 import (
 	"bytes"
 	"context"
+	"crypto/x509"
 	"fmt"
 	"net"
 
@@ -55,6 +56,11 @@ func (s *sessionUDP) LocalAddr() net.Addr {
 // RemoteAddr implements the networkSession.RemoteAddr method.
 func (s *sessionUDP) RemoteAddr() net.Addr {
 	return s.sessionUDPData.RemoteAddr()
+}
+
+// PeerCertificates implements the networkSession.PeerCertificates method.
+func (s *sessionUDP) PeerCertificates() []*x509.Certificate {
+	return nil
 }
 
 // BlockWiseTransferEnabled


### PR DESCRIPTION
This will, for example, allow the server to get the client certificate (chain) in case of DTLS.
The certificates can be accessed as `req.PeerCertificates` where `req` is of type `req *coap.Request`.

Fixes #103

@jkralik Could you please look at these changes? I'd love some feedback and am happy to change this in any way. The changes I've done now worked for me, but I'm not sure whether the way I've done these changes is preferred as I'm new to the codebase (and Go).

Some elements in specific I'm not sure about:
- In [net/conn.go](https://github.com/jdbruijn/go-coap/blob/bedcb6752729174f0306f22296298c4848a141fa/net/conn.go#L38) I'm exposing the `Conn`, which could be altered by the receiver if I'm not mistaken. Although the same goes for the `LocalAddr` and `RenoteAddr` functions, I'm not sure whether this is okay for the `Conn` too.
- Ignoring possible errors in the certificate parsing [here](https://github.com/jdbruijn/go-coap/blob/bedcb6752729174f0306f22296298c4848a141fa/server.go#L564). I've added a comment about it but if you look at it differntly, please let me know and I'll change it.


Attached is the patch file which I used to verify the workings of this since PSK doesn't have certificates of course.

[peer-certificates-test.patch.txt](https://github.com/go-ocf/go-coap/files/4380263/peer-certificates-test.patch.txt)

BTW: This time I've also ran the tests locally, so should be passing ;)