### PR TITLE
Add callback for errors occurring from listeners and fix DTLS accept loop from exiting

### DIFF
--- a/dtls_test.go
+++ b/dtls_test.go
@@ -128,11 +128,17 @@ func TestRSACerts(t *testing.T) {
 		ClientAuth:           dtls.RequireAnyClientCert,
 	}
 
+	listenerErrorHandler := func(err error) bool {
+		fmt.Fprintf(os.Stderr, "Listener error occurred: %v", err)
+		return true
+	}
+
 	s := &Server{
-		Net:        "udp-dtls",
-		Addr:       ":5688",
-		DTLSConfig: config,
-		Handler:    HandlerFunc(EchoServer),
+		Net:               "udp-dtls",
+		Addr:              ":5688",
+		DTLSConfig:        config,
+		Handler:           HandlerFunc(EchoServer),
+		listenerErrorFunc: listenerErrorHandler,
 	}
 	err = s.ListenAndServe()
 	require.Error(t, err)
@@ -155,10 +161,16 @@ func TestECDSACerts_PeerCertificate(t *testing.T) {
 	l, err := coapNet.NewDTLSListener("udp", ":", &config, time.Millisecond*100)
 	require.NoError(t, err)
 
+	listenerErrorHandler := func(err error) bool {
+		fmt.Fprintf(os.Stderr, "Listener error occurred: %v", err)
+		return true
+	}
+
 	s := &Server{
-		Net:       "udp-dtls",
-		Listener:  l,
-		KeepAlive: MustMakeKeepAlive(time.Second),
+		Net:               "udp-dtls",
+		Listener:          l,
+		KeepAlive:         MustMakeKeepAlive(time.Second),
+		listenerErrorFunc: listenerErrorHandler,
 	}
 	s.Handler = HandlerFunc(func(w ResponseWriter, r *Request) {
 		certs := r.Client.PeerCertificates()

--- a/examples/dtls/server/main.go
+++ b/examples/dtls/server/main.go
@@ -34,6 +34,11 @@ func main() {
 	mux.Handle("/a", coap.HandlerFunc(handleA))
 	mux.Handle("/b", coap.HandlerFunc(handleB))
 
+	listenerErrorHandler := func(err error) bool {
+		log.Printf("Listener error occurred: %v", err)
+		return true
+	}
+
 	log.Fatal(coap.ListenAndServeDTLS("udp", ":5688", &dtls.Config{
 		PSK: func(hint []byte) ([]byte, error) {
 			fmt.Printf("Client's hint: %s \n", hint)
@@ -41,5 +46,5 @@ func main() {
 		},
 		PSKIdentityHint: []byte("Pion DTLS Client"),
 		CipherSuites:    []dtls.CipherSuiteID{dtls.TLS_PSK_WITH_AES_128_CCM_8},
-	}, mux))
+	}, mux, listenerErrorHandler))
 }

--- a/examples/mcast/server/main.go
+++ b/examples/mcast/server/main.go
@@ -62,5 +62,10 @@ func main() {
 	mux := coap.NewServeMux()
 	mux.Handle("/oic/res", coap.HandlerFunc(handleMcast))
 
-	log.Fatal(coap.ListenAndServe("udp-mcast", "224.0.1.187:5688", mux))
+	listenerErrorHandler := func(err error) bool {
+		log.Printf("Listener error occurred: %v", err)
+		return true
+	}
+
+	log.Fatal(coap.ListenAndServe("udp-mcast", "224.0.1.187:5688", mux, listenerErrorHandler))
 }

--- a/examples/observe/server/main.go
+++ b/examples/observe/server/main.go
@@ -29,6 +29,11 @@ func periodicTransmitter(w coap.ResponseWriter, req *coap.Request) {
 }
 
 func main() {
+	listenerErrorHandler := func(err error) bool {
+		log.Printf("Listener error occurred: %v", err)
+		return true
+	}
+
 	log.Fatal(coap.ListenAndServe("udp", ":5688",
 		coap.HandlerFunc(func(w coap.ResponseWriter, req *coap.Request) {
 			log.Printf("Got message path=%q: %#v from %v", req.Msg.Path(), req.Msg, req.Client.RemoteAddr())
@@ -42,5 +47,5 @@ func main() {
 					log.Printf("Error on transmitter: %v", err)
 				}
 			}
-		})))
+		}), listenerErrorHandler))
 }

--- a/examples/ping/server/main.go
+++ b/examples/ping/server/main.go
@@ -32,5 +32,10 @@ func main() {
 		log.Fatalf("Run %v LISTEN_ADDRESS:PORT ", os.Args[0])
 	}
 
-	log.Fatal(coap.ListenAndServe("tcp", os.Args[1], coap.HandlerFunc(handleA)))
+	listenerErrorHandler := func(err error) bool {
+		log.Printf("Listener error occurred: %v", err)
+		return true
+	}
+
+	log.Fatal(coap.ListenAndServe("tcp", os.Args[1], coap.HandlerFunc(handleA), listenerErrorHandler))
 }

--- a/examples/simple/server/main.go
+++ b/examples/simple/server/main.go
@@ -38,5 +38,10 @@ func main() {
 	mux.Handle("/a", coap.HandlerFunc(handleA))
 	mux.Handle("/b", coap.HandlerFunc(handleB))
 
-	log.Fatal(coap.ListenAndServe("udp", ":5688", mux))
+	listenerErrorHandler := func(err error) bool {
+		log.Printf("Listener error occurred: %v", err)
+		return true
+	}
+
+	log.Fatal(coap.ListenAndServe("udp", ":5688", mux, listenerErrorHandler))
 }

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,7 @@ golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59 h1:3zb4D3T4G8jdExgVU/95+v
 golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e h1:3G+cUijn7XD+S4eJFddp53Pv7+slrESplyjG25HgL+k=
 golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/keepalive_test.go
+++ b/keepalive_test.go
@@ -117,6 +117,11 @@ func TestKeepAliveTCP_Server(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 
+	listenerErrorHandler := func(err error) bool {
+		fmt.Printf("Listener error occurred: %v", err)
+		return true
+	}
+
 	s := &Server{Listener: l, ReadTimeout: time.Second * 3600, WriteTimeout: time.Second * 3600,
 		NotifySessionNewFunc: func(s *ClientConn) {
 			fmt.Printf("networkSession start %v\n", s.RemoteAddr())
@@ -141,6 +146,7 @@ func TestKeepAliveTCP_Server(t *testing.T) {
 				}
 			},
 		},
+		listenerErrorFunc: listenerErrorHandler,
 	}
 	defer s.Shutdown()
 
@@ -167,6 +173,11 @@ func TestKeepAliveTCPTLS_Server(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 
+	listenerErrorHandler := func(err error) bool {
+		fmt.Printf("Listener error occurred: %v", err)
+		return true
+	}
+
 	s := &Server{Listener: l, ReadTimeout: time.Second * 3600, WriteTimeout: time.Second * 3600,
 		NotifySessionNewFunc: func(s *ClientConn) {
 			fmt.Printf("networkSession start %v\n", s.RemoteAddr())
@@ -191,6 +202,7 @@ func TestKeepAliveTCPTLS_Server(t *testing.T) {
 				}
 			},
 		},
+		listenerErrorFunc: listenerErrorHandler,
 	}
 	defer s.Shutdown()
 
@@ -214,6 +226,11 @@ func TestKeepAliveUDP_Server(t *testing.T) {
 
 	var wg sync.WaitGroup
 	wg.Add(1)
+
+	listenerErrorHandler := func(err error) bool {
+		fmt.Printf("Listener error occurred: %v", err)
+		return true
+	}
 
 	s := &Server{ReadTimeout: time.Second * 3600, WriteTimeout: time.Second * 3600,
 		NotifySessionNewFunc: func(s *ClientConn) {
@@ -239,6 +256,7 @@ func TestKeepAliveUDP_Server(t *testing.T) {
 				}
 			},
 		},
+		listenerErrorFunc: listenerErrorHandler,
 	}
 	defer s.Shutdown()
 
@@ -272,6 +290,11 @@ func TestKeepAliveDTLS_Server(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 
+	listenerErrorHandler := func(err error) bool {
+		fmt.Printf("Listener error occurred: %v", err)
+		return true
+	}
+
 	s := &Server{Listener: l, ReadTimeout: time.Second * 3600, WriteTimeout: time.Second * 3600,
 		NotifySessionNewFunc: func(s *ClientConn) {
 			fmt.Printf("networkSession start %v\n", s.RemoteAddr())
@@ -296,6 +319,7 @@ func TestKeepAliveDTLS_Server(t *testing.T) {
 				}
 			},
 		},
+		listenerErrorFunc: listenerErrorHandler,
 	}
 	defer s.Shutdown()
 

--- a/net/dtlslistener.go
+++ b/net/dtlslistener.go
@@ -35,7 +35,7 @@ func (l *DTLSListener) acceptLoop() {
 		select {
 		case l.connCh <- connData{conn: conn, err: err}:
 			if err != nil {
-				return
+				continue
 			}
 		case <-l.doneCh:
 			return

--- a/net/dtlslistener.go
+++ b/net/dtlslistener.go
@@ -34,9 +34,6 @@ func (l *DTLSListener) acceptLoop() {
 		conn, err := l.listener.Accept()
 		select {
 		case l.connCh <- connData{conn: conn, err: err}:
-			if err != nil {
-				continue
-			}
 		case <-l.doneCh:
 			return
 		}
@@ -80,7 +77,7 @@ func (l *DTLSListener) AcceptWithContext(ctx context.Context) (net.Conn, error) 
 		}
 		err := l.SetDeadline(time.Now().Add(l.heartBeat))
 		if err != nil {
-			return nil, fmt.Errorf("cannot set deadline accept connection: %v", err)
+			return nil, fmt.Errorf("cannot set deadline to accept connection: %v", err)
 		}
 		rw, err := l.Accept()
 		if err != nil {

--- a/net/dtlslistener.go
+++ b/net/dtlslistener.go
@@ -80,14 +80,14 @@ func (l *DTLSListener) AcceptWithContext(ctx context.Context) (net.Conn, error) 
 		}
 		err := l.SetDeadline(time.Now().Add(l.heartBeat))
 		if err != nil {
-			return nil, fmt.Errorf("cannot accept connections: %v", err)
+			return nil, fmt.Errorf("cannot set deadline accept connection: %v", err)
 		}
 		rw, err := l.Accept()
 		if err != nil {
 			if isTemporary(err) {
 				continue
 			}
-			return nil, fmt.Errorf("cannot accept connections: %v", err)
+			return nil, fmt.Errorf("cannot accept connection: %v", err)
 		}
 		return rw, nil
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -137,6 +137,11 @@ func RunLocalServerTCPWithHandler(laddr string, BlockWiseTransfer bool, BlockWis
 		return nil, "", nil, fmt.Errorf("cannot create new tls listener: %v", err)
 	}
 
+	listenerErrorHandler := func(err error) bool {
+		fmt.Printf("Listener error occurred: %v", err)
+		return true
+	}
+
 	server := &Server{Listener: l, ReadTimeout: time.Second * 3600, WriteTimeout: time.Second * 3600,
 		NotifySessionNewFunc: func(s *ClientConn) {
 			fmt.Printf("networkSession start %v\n", s.RemoteAddr())
@@ -146,6 +151,7 @@ func RunLocalServerTCPWithHandler(laddr string, BlockWiseTransfer bool, BlockWis
 		BlockWiseTransfer:    &BlockWiseTransfer,
 		BlockWiseTransferSzx: &BlockWiseTransferSzx,
 		MaxMessageSize:       ^uint32(0),
+		listenerErrorFunc:    listenerErrorHandler,
 	}
 
 	waitLock := sync.Mutex{}
@@ -203,6 +209,11 @@ func RunLocalDTLSServer(laddr string, config *dtls.Config, BlockWiseTransfer boo
 		return nil, "", nil, err
 	}
 
+	listenerErrorHandler := func(err error) bool {
+		fmt.Printf("Listener error occurred: %v", err)
+		return true
+	}
+
 	server := &Server{Listener: l, ReadTimeout: time.Hour, WriteTimeout: time.Hour,
 		BlockWiseTransfer:    &BlockWiseTransfer,
 		BlockWiseTransferSzx: &BlockWiseTransferSzx,
@@ -211,7 +222,8 @@ func RunLocalDTLSServer(laddr string, config *dtls.Config, BlockWiseTransfer boo
 		}, NotifySessionEndFunc: func(w *ClientConn, err error) {
 			fmt.Printf("networkSession end %v: %v\n", w.RemoteAddr(), err)
 		},
-		MaxMessageSize: ^uint32(0),
+		MaxMessageSize:    ^uint32(0),
+		listenerErrorFunc: listenerErrorHandler,
 	}
 
 	// fin must be buffered so the goroutine below won't block

--- a/server_test.go
+++ b/server_test.go
@@ -96,6 +96,11 @@ func RunLocalServerUDPWithHandlerIfaces(lnet, laddr string, BlockWiseTransfer bo
 		}
 	}
 
+	listenerErrorHandler := func(err error) bool {
+		fmt.Printf("Listener error occurred: %v", err)
+		return true
+	}
+
 	server := &Server{ReadTimeout: time.Hour, WriteTimeout: time.Hour,
 		NotifySessionNewFunc: func(s *ClientConn) {
 			fmt.Printf("networkSession start %v\n", s.RemoteAddr())
@@ -106,6 +111,7 @@ func RunLocalServerUDPWithHandlerIfaces(lnet, laddr string, BlockWiseTransfer bo
 		Handler:              handler,
 		BlockWiseTransfer:    &BlockWiseTransfer,
 		BlockWiseTransferSzx: &BlockWiseTransferSzx,
+		listenerErrorFunc:    listenerErrorHandler,
 	}
 
 	waitLock := sync.Mutex{}
@@ -181,13 +187,19 @@ func RunLocalTLSServer(laddr string, config *tls.Config) (*Server, string, chan 
 		return nil, "", nil, err
 	}
 
+	listenerErrorHandler := func(err error) bool {
+		fmt.Printf("Listener error occurred: %v", err)
+		return true
+	}
+
 	server := &Server{Listener: l, ReadTimeout: time.Hour, WriteTimeout: time.Hour,
 		NotifySessionNewFunc: func(s *ClientConn) {
 			fmt.Printf("networkSession start %v\n", s.RemoteAddr())
 		}, NotifySessionEndFunc: func(w *ClientConn, err error) {
 			fmt.Printf("networkSession end %v: %v\n", w.RemoteAddr(), err)
 		},
-		MaxMessageSize: ^uint32(0),
+		MaxMessageSize:    ^uint32(0),
+		listenerErrorFunc: listenerErrorHandler,
 	}
 
 	// fin must be buffered so the goroutine below won't block


### PR DESCRIPTION
@jkralik As per issue #67, implemented callbacks into listeners to return back error messages on any failures.  Also fixed a bug where the DTLS accept loop would exit if a single session has a handshake failure