### PR TITLE
export message.GetMID() as global function

### DIFF
--- a/dtls/client_test.go
+++ b/dtls/client_test.go
@@ -200,7 +200,7 @@ func TestClientConn_Get_SeparateMessage(t *testing.T) {
 	req, err := client.NewGetRequest(ctx, "/a")
 	require.NoError(t, err)
 	req.SetType(udpMessage.Confirmable)
-	req.SetMessageID(cc.GetMID())
+	req.SetMessageID(udpMessage.GetMID())
 	resp, err := cc.Do(req)
 	require.NoError(t, err)
 	assert.Equal(t, codes.Content, resp.Code())

--- a/udp/client/client.go
+++ b/udp/client/client.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/go-ocf/go-coap/v2/message"
 	"github.com/go-ocf/go-coap/v2/mux"
+	udpMessage "github.com/go-ocf/go-coap/v2/udp/message"
 	"github.com/go-ocf/go-coap/v2/udp/message/pool"
 )
 
@@ -77,7 +78,7 @@ func (c *Client) WriteMessage(req *message.Message) error {
 	if err != nil {
 		return err
 	}
-	r.SetMessageID(c.cc.GetMID())
+	r.SetMessageID(udpMessage.GetMID())
 	defer pool.ReleaseMessage(r)
 	return c.cc.WriteMessage(r)
 }

--- a/udp/client/clientconn_test.go
+++ b/udp/client/clientconn_test.go
@@ -183,7 +183,7 @@ func TestClientConn_Get_SeparateMessage(t *testing.T) {
 	req, err := client.NewGetRequest(ctx, "/a")
 	require.NoError(t, err)
 	req.SetType(udpMessage.Confirmable)
-	req.SetMessageID(cc.GetMID())
+	req.SetMessageID(udpMessage.GetMID())
 	resp, err := cc.Do(req)
 	require.NoError(t, err)
 	assert.Equal(t, codes.Content, resp.Code())

--- a/udp/client_test.go
+++ b/udp/client_test.go
@@ -184,7 +184,7 @@ func TestClientConn_Get_SeparateMessage(t *testing.T) {
 	req, err := client.NewGetRequest(ctx, "/a")
 	require.NoError(t, err)
 	req.SetType(udpMessage.Confirmable)
-	req.SetMessageID(cc.GetMID())
+	req.SetMessageID(udpMessage.GetMID())
 	resp, err := cc.Do(req)
 	require.NoError(t, err)
 	assert.Equal(t, codes.Content, resp.Code())

--- a/udp/discover.go
+++ b/udp/discover.go
@@ -6,6 +6,7 @@ import (
 	"net"
 
 	"github.com/go-ocf/go-coap/v2/udp/client"
+	"github.com/go-ocf/go-coap/v2/udp/message"
 	"github.com/go-ocf/go-coap/v2/udp/message/pool"
 )
 
@@ -28,7 +29,7 @@ func (s *Server) Discover(ctx context.Context, multicastAddr, path string, recei
 	if err != nil {
 		return fmt.Errorf("cannot create discover request: %w", err)
 	}
-	req.SetMessageID(s.GetMID())
+	req.SetMessageID(message.GetMID())
 	defer pool.ReleaseMessage(req)
 	return s.DiscoveryRequest(req, multicastAddr, receiverFunc, opts...)
 }

--- a/udp/message/error.go
+++ b/udp/message/error.go
@@ -1,4 +1,4 @@
-package udp
+package message
 
 import "errors"
 

--- a/udp/message/getmid.go
+++ b/udp/message/getmid.go
@@ -1,0 +1,20 @@
+package message
+
+import (
+	"crypto/rand"
+	"encoding/binary"
+	"sync/atomic"
+)
+
+var msgID uint32
+
+func init() {
+	b := make([]byte, 4)
+	rand.Read(b)
+	msgID = binary.BigEndian.Uint32(b)
+}
+
+// GetMID generates a message id for UDP-coap
+func GetMID() uint16 {
+	return uint16(atomic.AddUint32(&msgID, 1))
+}

--- a/udp/message/message.go
+++ b/udp/message/message.go
@@ -1,4 +1,4 @@
-package udp
+package message
 
 import (
 	"encoding/binary"

--- a/udp/message/message_test.go
+++ b/udp/message/message_test.go
@@ -1,4 +1,4 @@
-package udp
+package message
 
 import (
 	"testing"

--- a/udp/message/type.go
+++ b/udp/message/type.go
@@ -1,4 +1,4 @@
-package udp
+package message
 
 import (
 	"strconv"


### PR DESCRIPTION
iotivity-lite checks for duplicate message via MID so it can drop
request when app uses more clients then one. To avoid issue GetMID
needs to be global function.