### PR TITLE
fix: use loop index to calculate used length of options

### DIFF
--- a/message/options.go
+++ b/message/options.go
@@ -536,7 +536,7 @@ func (options Options) ResetOptionsTo(buf []byte, in Options) (Options, int, err
 	for idx, o := range in {
 		if len(buf) < len(o.Value) {
 			for i := idx; i < len(in); i++ {
-				used += len(in[idx].Value)
+				used += len(in[i].Value)
 			}
 			return options, used, ErrTooSmall
 		}


### PR DESCRIPTION
The wrong index variable in the loop was used, potentially causing not enough bytes allocated for the next cycle of the mux options conversion.